### PR TITLE
FunSQL.reflect() includes table_catalog for DuckDB 

### DIFF
--- a/src/connections.jl
+++ b/src/connections.jl
@@ -62,6 +62,7 @@ const DB = SQLConnection
 """
     DBInterface.connect(DB{RawConnType},
                         args...;
+                        catalog = nothing,
                         schema = nothing,
                         dialect = nothing,
                         cache = $default_cache_maxsize,
@@ -75,13 +76,13 @@ Extra parameters `args` and `kws` are passed to the call:
     DBInterface.connect(RawConnType, args...; kws...)
 """
 function DBInterface.connect(::Type{SQLConnection{RawConnType}}, args...;
+                             catalog = nothing,
                              schema = nothing,
                              dialect = nothing,
                              cache = default_cache_maxsize,
                              kws...) where {RawConnType}
     raw = DBInterface.connect(RawConnType, args...; kws...)
-    catalog = reflect(raw, schema = schema, dialect = dialect, cache = cache)
-    SQLConnection{RawConnType}(raw, catalog = catalog)
+    SQLConnection{RawConnType}(raw; catalog = reflect(raw; catalog, schema, dialect, cache))
 end
 
 """

--- a/src/reflect.jl
+++ b/src/reflect.jl
@@ -86,15 +86,16 @@ reflect_sql(d::SQLDialect) =
 
 """
     reflect(conn;
+            catalog = nothing,
             schema = nothing,
             dialect = nothing,
             cache = $default_cache_maxsize)::SQLCatalog
 
 Retrieve the information about available database tables.
 
-The function returns a [`SQLCatalog`](@ref) object.  The catalog
-will be populated with the tables from the given database `schema`, or,
-if parameter `schema` is not set, from the default database schema
+The function returns a [`SQLCatalog`](@ref) object.  The catalog will be
+populated with the tables from the given database `catalog` and `schema`.
+If these parameters are not set, the default catalog and schema are assumed
 (e.g., schema `public` for PostgreSQL).
 
 Parameter `dialect` specifies the target [`SQLDialect`](@ref).  If not set,


### PR DESCRIPTION
In DuckDB you can use "ATTACH" to mount an external (read only) DuckDB file to a catalog. This can be done on an in-memory scratch database. Unfortunately, existing FunSQL `reflect()` doesn't support filtering by catalog nor building of FunSQL catalog with the SQL qualifiers. Qualifiers are implemented in FunSQL just that `reflect()` doesn't set them up.