### PR TITLE
Allows `SQLDialect` to be inferred from the type `SQLConnection`.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# VS Code settings
+.vscode/
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-# VS Code settings
-.vscode/
-.DS_Store

--- a/src/connections.jl
+++ b/src/connections.jl
@@ -17,6 +17,9 @@ end
 SQLConnection(raw::RawConnType; catalog) where {RawConnType} =
     SQLConnection{RawConnType}(raw, catalog = catalog)
 
+SQLDialect(::Type{SQLConnection{RawConnType}}) where {RawConnType} =
+    SQLDialect(RawConnType)
+
 function Base.show(io::IO, conn::SQLConnection)
     print(io, "SQLConnection(")
     show(io, conn.raw)


### PR DESCRIPTION
Not sure if you're accepting pull requests, but here's a small edit.

```julia
import SQLite
import FunSQL: DBInterface, SQLConnection, reflect
DBInterface.connect(SQLConnection{SQLite.DB}) |> reflect  # `reflect` now works on the type `SQLConnection`.
```

If you think there is a better way to do this, please go ahead and ignore this pull request.